### PR TITLE
Fix Invalid definition for service "fos_user.user_manager"

### DIFF
--- a/Resources/config/doctrine.xml
+++ b/Resources/config/doctrine.xml
@@ -13,7 +13,7 @@
         </service>
 
         <!-- The factory is configured in the DI extension class to support more Symfony versions -->
-        <service id="fos_user.object_manager" class="Doctrine\Common\Persistence\ObjectManager" public="false">
+        <service id="fos_user.object_manager" class="Doctrine\ORM\EntityManagerInterface" public="false">
             <argument>%fos_user.model_manager_name%</argument>
         </service>
 


### PR DESCRIPTION
Fix: Invalid definition for service "fos_user.user_manager": argument 3 of "FOS\UserBundle\Doctrine\UserManager::__construct()" accepts "Doctrine\ORM\EntityManagerInterface", "Doctrine\Common\Persistence\ObjectManager" passed.